### PR TITLE
Enable Ghostty shell integration under tmux

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -82,3 +82,9 @@ alias ls='ls -la -G'
 # for Mac
 alias ls='gls -la --color'
 alias awk='gawk'
+
+# Ghostty shell integration (tmux 内でも動くよう明示 source)
+if [[ -r /Applications/Ghostty.app/Contents/Resources/ghostty/shell-integration/zsh/ghostty-integration ]]; then
+  export GHOSTTY_RESOURCES_DIR=/Applications/Ghostty.app/Contents/Resources/ghostty
+  source "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
+fi

--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -11,6 +11,14 @@ set -sg escape-time 1
 # OSC 52 でシステムクリップボードにコピーする
 set -g set-clipboard on
 
+# プロンプト間ジャンプ(zsh の OSC 133 マーカーを利用)
+# prefix + ↑/↓ で copy-mode に入りつつ前後のプロンプトへ
+# copy-mode 内では M-↑/↓ で続けてジャンプ
+bind-key Up   copy-mode \; send-keys -X previous-prompt
+bind-key Down copy-mode \; send-keys -X next-prompt
+bind-key -T copy-mode M-Up   send-keys -X previous-prompt
+bind-key -T copy-mode M-Down send-keys -X next-prompt
+
 # 設定ファイルをリロードする
 bind r source-file ~/.tmux.conf \; display "Reloaded!"
 


### PR DESCRIPTION
## Summary
- Source Ghostty's zsh integration script from `~/.zshrc` so OSC 133 markers and prompt-jump (`Cmd+Shift+Up/Down`), command-bounded selection, exit-code visualization, and CWD propagation work inside tmux panes — not just shells spawned directly by Ghostty.
- Hardcode `GHOSTTY_RESOURCES_DIR` to the standard `/Applications` install path; the env var is otherwise not propagated through a tmux server that was started from another terminal (e.g. iTerm2 pre-migration).

## Test plan
- [x] `source ~/.zshrc` in a tmux pane and confirm Ghostty prompt-jump (`Cmd+Shift+Up`) scrolls to the previous prompt.
- [ ] Confirm CWD inheritance: open a new Ghostty tab from a tmux pane and verify it starts in the same directory (deferred until tmux server is restarted from Ghostty).