### PR TITLE
Fix mac_install.sh: brew cask syntax and https git protocol

### DIFF
--- a/mac_install.sh
+++ b/mac_install.sh
@@ -15,7 +15,7 @@ brew install --cask ghostty
 brew install --cask font-jetbrains-mono-nerd-font
 
 # install Emacs (with cocoa)
-brew cask install emacs
+brew install --cask emacs
 git clone git@github.com:syohex/emacs-digdag-mode.git ~/.emacs.d/github.com/
 install ./.emacs.d/init.el ~/.emacs.d/
 
@@ -26,7 +26,7 @@ install ./.vimrc ~/
 install -D ./ghostty/config ~/.config/ghostty/config
 
 # NeoBundle (for Vim) install
-git clone git://github.com/Shougo/neobundle.vim ~/.vim/bundle/neobundle.vim
+git clone https://github.com/Shougo/neobundle.vim ~/.vim/bundle/neobundle.vim
 
 # Docker settings
 install ./.docker/config.json ~/.docker


### PR DESCRIPTION
## Summary
- Replace the removed `brew cask install` syntax with `brew install --cask` (Homebrew dropped the standalone `cask` subcommand in 2.6).
- Switch the NeoBundle clone from `git://` to `https://` because GitHub disabled the unauthenticated git protocol in 2021.

Both are silent breakages today — the script would fail partway through a fresh-machine setup without either fix.

## Test plan
- [x] `bash -n mac_install.sh` (syntax-only) passes.
- [ ] Full `mac_install.sh` run on a clean machine (deferred — covered by next setup).