### PR TITLE
Modernize tmux defaults and plugin layout

### DIFF
--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -34,8 +34,9 @@ set -g renumber-windows on
 ## ステータスバーを上部に表示する
 set -g status-position top
 
-# 256色端末を使用する
-set -g default-terminal "screen-256color"
+# 256色 + true color。外側ターミナル(Ghostty 等)の RGB を活かす
+set -g default-terminal "tmux-256color"
+set -as terminal-features ",xterm-ghostty:RGB,xterm-256color:RGB"
 
 # ステータスバーの色を設定する
 setw -g status-bg brightblue
@@ -62,3 +63,12 @@ set -g pane-border-style bg="black",fg="brightblue"
 
 # アクティブなペインを目立たせる
 set -g pane-active-border-style bg="yellow",fg="white"
+
+# Plugins (tpm)
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+
+# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
- Replace `default-terminal "screen-256color"` with `tmux-256color`, and declare RGB support for `xterm-ghostty` and `xterm-256color` via `terminal-features`. Unlocks true-color and modern features that the old terminfo was hiding from tmux.
- Reflect the tpm plugins (`tmux-sensible`, `tmux-resurrect`, `tmux-continuum`) that the running config already loaded but the repo was missing. Also reorder so `run '~/.tmux/plugins/tpm/tpm'` is the final line — tpm ignores any `@plugin` declared after that `run` call.

## Test plan
- [x] `tmux source-file ~/.tmux.conf` reloads cleanly.
- [x] `tmux show-options -g default-terminal` reports `tmux-256color`.
- [x] `tmux show-options -As terminal-features` lists `xterm-ghostty:RGB`.
- [ ] Confirm tpm picks up all four plugins on next `prefix + I`.