### PR TITLE
Stop Ghostty shell integration from rewriting window titles

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -14,7 +14,7 @@ theme = "Catppuccin Mocha"
 
 # Shell integration (zsh) — プロンプト間ジャンプ・実行時間・exit status 等
 shell-integration = zsh
-shell-integration-features = cursor,sudo,title
+shell-integration-features = cursor,sudo
 
 # Quick terminal: Cmd+` で Quake 風ドロップダウン
 keybind = global:cmd+grave_accent=toggle_quick_terminal


### PR DESCRIPTION
## Summary
- Drop `title` from `shell-integration-features`. The feature drives Ghostty's tab/window title from the active command name, which shows up as noisy labels like `tm` whenever a short alias is in the foreground. Keep `cursor` and `sudo` — they are not visible noise.

## Test plan
- [x] `Cmd+Q` Ghostty and relaunch.
- [ ] Confirm the tab/window title no longer flips to the current command name.