### PR TITLE
Replace SSIA README with install steps and repo layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # dotfiles
-SSIA
+
+Personal dotfiles for macOS (Apple Silicon).
+
+## Install
+
+```sh
+git clone git@github.com:zettaittenani/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+bash mac_install.sh
+```
+
+`mac_install.sh` is idempotent — re-running it is safe.
+
+## What gets installed
+
+- Homebrew + tmux + Emacs (cask) + coreutils + gawk
+- Ghostty + JetBrainsMono Nerd Font (cask)
+- Config files:
+  - `~/.zshrc`
+  - `~/.vimrc`
+  - `~/.tmux.conf` (from `tmux/2.9/`)
+  - `~/.config/ghostty/config`
+  - `~/.docker/config.json`
+- NeoBundle for Vim (under `~/.vim/bundle/`)
+- `emacs-digdag-mode` (under `~/.emacs.d/`)
+
+## Layout
+
+```
+.
+├── .docker/        # Docker client config
+├── .emacs.d/       # Emacs init.el
+├── .vimrc
+├── .zshrc
+├── ghostty/        # → ~/.config/ghostty/
+├── tmux/2.9/       # → ~/.tmux.conf (tmux 2.9+)
+├── Dockerfile      # data science notebook image (legacy)
+└── mac_install.sh
+```


### PR DESCRIPTION
## Summary
- Replace the single-line `SSIA` README with a real one: install one-liner, what gets installed by `mac_install.sh`, and the directory layout.

## Test plan
- [x] `git diff master -- README.md` renders cleanly.