### PR TITLE
Remove legacy regex engine override from vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -12,7 +12,6 @@ set scrolloff=10
 set shiftwidth=2
 set noswapfile "スワップファイルを作らない
 set showcmd
-set re=1
 
 set background=dark
 set termguicolors


### PR DESCRIPTION
## Summary
- Delete `set re=1`. Modern Vim auto-selects its regex engine; pinning to the old NFA-based engine only blocks newer improvements without solving any current problem.

## Test plan
- [x] Open a TypeScript / Ruby file in Vim and confirm syntax highlighting is responsive.