### PR TITLE
Install dev runtime managers used by zshrc

### DIFF
--- a/mac_install.sh
+++ b/mac_install.sh
@@ -35,3 +35,10 @@ install ./.docker/config.json ~/.docker
 brew install coreutils
 brew install gawk
 brew link --overwrite gawk
+
+# Dev runtime managers and tooling used by ~/.zshrc
+brew install direnv
+brew install jenv
+brew install fnm
+brew install mise
+brew install pnpm


### PR DESCRIPTION
## Summary
- Add `brew install` lines for direnv, jenv, fnm, mise, and pnpm. The running `~/.zshrc` evals all of these, but the install script was leaving them out, so a fresh machine errored on shell startup until each was installed by hand.

## Test plan
- [x] `bash -n mac_install.sh` passes.
- [ ] `mac_install.sh` end-to-end on a clean machine (deferred — covered by next setup).