### PR TITLE
Migrate vim plugin manager from NeoBundle to vim-plug

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -71,32 +71,30 @@ set backspace=indent,eol,start
 " nerdtree shortcut
 nnoremap <silent><C-e> :NERDTreeToggle<CR>
 
-" You need: 'git clone git://github.com/Shougo/neobundle.vim ~/.vim/bundle/neobundle.vim'
-if has('vim_starting')
-  set runtimepath+=~/.vim/bundle/neobundle.vim/
-endif
 autocmd BufRead,BufNewFile *.slim setfiletype slim
-call neobundle#begin(expand('~/.vim/bundle/'))
-NeoBundle 'Shougo/neobundle.vim'
-NeoBundle 'Shougo/neocomplcache'
-NeoBundle 'Shougo/unite.vim'
-NeoBundle 'Shougo/neoyank.vim'
-NeoBundle 'thinca/vim-quickrun'
-NeoBundle 'thinca/vim-ref'
-NeoBundle "ctrlpvim/ctrlp.vim"
-NeoBundle 'slim-template/vim-slim'
-NeoBundle 'scrooloose/nerdtree'
-NeoBundle 'tpope/vim-rails'
-NeoBundle 'tpope/vim-endwise'
-NeoBundle 'tpope/vim-fugitive'
-NeoBundle 'soramugi/auto-ctags.vim'
-NeoBundle 'derekwyatt/vim-scala'
-call neobundle#end()
+
+" vim-plug: install with
+"   sh -c 'curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+"     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+" Then run :PlugInstall inside vim.
+call plug#begin('~/.vim/plugged')
+Plug 'Shougo/neocomplcache.vim'
+Plug 'Shougo/unite.vim'
+Plug 'Shougo/neoyank.vim'
+Plug 'thinca/vim-quickrun'
+Plug 'thinca/vim-ref'
+Plug 'ctrlpvim/ctrlp.vim'
+Plug 'slim-template/vim-slim'
+Plug 'preservim/nerdtree'
+Plug 'tpope/vim-rails'
+Plug 'tpope/vim-endwise'
+Plug 'tpope/vim-fugitive'
+Plug 'soramugi/auto-ctags.vim'
+Plug 'derekwyatt/vim-scala'
+call plug#end()
 
 filetype plugin indent on
 filetype indent on
-
-NeoBundleCheck
 
 " neocomplecache の設定
 " Disable AutoComplPop.

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -25,8 +25,9 @@ install ./tmux/2.9/.tmux.conf ~/
 install ./.vimrc ~/
 install -D ./ghostty/config ~/.config/ghostty/config
 
-# NeoBundle (for Vim) install
-git clone https://github.com/Shougo/neobundle.vim ~/.vim/bundle/neobundle.vim
+# vim-plug (for Vim) install. Run `:PlugInstall` inside vim afterwards.
+sh -c 'curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 
 # Docker settings
 install ./.docker/config.json ~/.docker


### PR DESCRIPTION
## Summary

- NeoBundle has been deprecated and unmaintained for years; replace it with `vim-plug`, the modern, simpler, actively maintained alternative.
- `.vimrc`: swap the `NeoBundle*` block for a `plug#begin` / `Plug` / `plug#end` block. Plugin set is preserved except:
  - `scrooloose/nerdtree` → `preservim/nerdtree` (new official org)
  - `Shougo/neocomplcache` → `Shougo/neocomplcache.vim` (correct repo name)
- `mac_install.sh`: drop the NeoBundle `git clone` step and install vim-plug via its upstream one-liner. Run `:PlugInstall` inside vim afterwards.

## Test plan

- [x] `~/.vim/autoload/plug.vim` exists after running the install snippet
- [x] `vim +PlugInstall +qall` installs all 13 plugins into `~/.vim/plugged/`
- [x] vim opens cleanly with no `NeoBundle` errors