### PR TITLE
Switch Ghostty font from JetBrainsMono to Hack Nerd Font

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bash mac_install.sh
 ## What gets installed
 
 - Homebrew + tmux + Emacs (cask) + coreutils + gawk
-- Ghostty + JetBrainsMono Nerd Font (cask)
+- Ghostty + Hack Nerd Font (cask)
 - Config files:
   - `~/.zshrc`
   - `~/.vimrc`

--- a/ghostty/config
+++ b/ghostty/config
@@ -6,7 +6,7 @@ copy-on-select = clipboard
 macos-option-as-alt = left
 
 # Font
-font-family = "JetBrainsMono Nerd Font Mono"
+font-family = "Hack Nerd Font Mono"
 font-size = 14
 
 # Theme

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -12,7 +12,7 @@ brew install tmux
 
 # install Ghostty and its font
 brew install --cask ghostty
-brew install --cask font-jetbrains-mono-nerd-font
+brew install --cask font-hack-nerd-font
 
 # install Emacs (with cocoa)
 brew install --cask emacs


### PR DESCRIPTION
## Summary

- JetBrainsMono had a few character shapes (italics, `g`, `l`) that grew tiring during daily use. Hack is the calm, neutral alternative — no ligatures, clear `0/O/l/1` disambiguation, very readable at small sizes.
- Still a Nerd Font patch, so tmux / prompt glyphs (powerline arrows, file-type icons, etc.) keep working.

## Changes

- \`ghostty/config\`: \`font-family = "Hack Nerd Font Mono"\`
- \`mac_install.sh\`: \`brew install --cask font-hack-nerd-font\`
- \`README.md\`: update the font name in the "What gets installed" list

## Test plan

- [x] \`brew install --cask font-hack-nerd-font\` succeeds
- [x] Ghostty picks up the new font after \`Cmd+Shift+,\` (reload config)
- [x] Nerd Font glyphs still render correctly in tmux / prompt