### PR TITLE
Switch Ghostty font to macOS built-in Monaco

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bash mac_install.sh
 ## What gets installed
 
 - Homebrew + tmux + Emacs (cask) + coreutils + gawk
-- Ghostty + Hack Nerd Font (cask)
+- Ghostty (cask; font is macOS built-in Monaco)
 - Config files:
   - `~/.zshrc`
   - `~/.vimrc`

--- a/ghostty/config
+++ b/ghostty/config
@@ -6,7 +6,7 @@ copy-on-select = clipboard
 macos-option-as-alt = left
 
 # Font
-font-family = "Hack Nerd Font Mono"
+font-family = "Monaco"
 font-size = 14
 
 # Theme

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -10,9 +10,8 @@ set -ex
 # install tmux
 brew install tmux
 
-# install Ghostty and its font
+# install Ghostty (font is macOS built-in Monaco)
 brew install --cask ghostty
-brew install --cask font-hack-nerd-font
 
 # install Emacs (with cocoa)
 brew install --cask emacs


### PR DESCRIPTION
## Summary

After cycling through JetBrainsMono → Hack → HackGen / HackGen35, Monaco (iTerm2's classic default) turned out to be the most comfortable. No need for Nerd Font glyphs in the current tmux / prompt setup, so we drop the Nerd Font cask entirely — Monaco ships with macOS so install footprint shrinks too.

## Changes

- \`ghostty/config\`: \`font-family = "Monaco"\`
- \`mac_install.sh\`: remove \`brew install --cask font-hack-nerd-font\` (no font cask needed)
- \`README.md\`: update "What gets installed" to reflect the built-in font

## Test plan

- [x] Ghostty renders Monaco after reload (SIGUSR2 / new window)
- [x] Japanese characters fall back to system Hiragino, no rendering issues for current workflow
- [x] \`mac_install.sh\` still completes end-to-end without the font cask line