### PR TITLE
Add workmux + tmux-agent-sidebar tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ bash mac_install.sh
 
 - Homebrew + tmux + Emacs (cask) + coreutils + gawk
 - Ghostty (cask; font is macOS built-in Monaco)
+- [`workmux`](https://github.com/raine/workmux) — git worktree + tmux window orchestrator
+- [`tmux-agent-sidebar`](https://github.com/hiroppy/tmux-agent-sidebar) — sidebar that tracks Claude Code / Codex / OpenCode panes (installed via `tpm`)
 - Config files:
   - `~/.zshrc`
   - `~/.vimrc`

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -42,3 +42,7 @@ brew install jenv
 brew install fnm
 brew install mise
 brew install pnpm
+
+# Tmux companion tooling
+# - workmux: git worktree + tmux window orchestrator
+brew install raine/workmux/workmux

--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -69,6 +69,7 @@ set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @plugin 'hiroppy/tmux-agent-sidebar'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary

Two terminal-side companion tools for the agent-heavy workflow:

- **[workmux](https://github.com/raine/workmux)** — bundles "create a git worktree + open a dedicated tmux window for it" into a single command (`workmux add <branch>`), and tears it all back down on `workmux merge`.
- **[tmux-agent-sidebar](https://github.com/hiroppy/tmux-agent-sidebar)** — single sidebar that tracks every Claude Code / Codex / OpenCode pane across sessions: prompts, status, git state, desktop notifications.

## Changes

- \`mac_install.sh\`: \`brew install raine/workmux/workmux\`
- \`tmux/2.9/.tmux.conf\`: register \`hiroppy/tmux-agent-sidebar\` as a tpm plugin
- \`README.md\`: link both tools in "What gets installed"

## Manual steps after this PR

These cannot be scripted into \`mac_install.sh\` cleanly:

1. \`prefix + I\` (or run \`~/.tmux/plugins/tpm/bin/install_plugins\`) — fetches the plugin
2. First sidebar launch triggers an install wizard that downloads the prebuilt binary
3. To wire it into Claude Code, run inside a Claude Code session:
   \`\`\`
   /plugin marketplace add ~/.tmux/plugins/tmux-agent-sidebar
   /plugin install tmux-agent-sidebar@hiroppy
   \`\`\`

## Test plan

- [x] \`brew install raine/workmux/workmux\` succeeds locally; \`workmux --version\` prints
- [x] \`install_plugins\` pulls the plugin into \`~/.tmux/plugins/tmux-agent-sidebar/\`
- [x] \`install-wizard.sh download-binary\` fetches \`bin/tmux-agent-sidebar\`
- [x] Existing tpm-managed plugins (resurrect, continuum, sensible) keep working