### PR TITLE
Install rustup + default stable toolchain

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -85,6 +85,9 @@ alias ls='ls -la -G'
 alias ls='gls -la --color'
 alias awk='gawk'
 
+# Rust toolchain (managed by Homebrew's rustup; shims at $brew/opt/rustup/bin)
+export PATH="/opt/homebrew/opt/rustup/bin:$PATH"
+
 # Ghostty shell integration (tmux 内でも動くよう明示 source)
 if [[ -r /Applications/Ghostty.app/Contents/Resources/ghostty/shell-integration/zsh/ghostty-integration ]]; then
   export GHOSTTY_RESOURCES_DIR=/Applications/Ghostty.app/Contents/Resources/ghostty

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -46,3 +46,8 @@ brew install pnpm
 # Tmux companion tooling
 # - workmux: git worktree + tmux window orchestrator
 brew install raine/workmux/workmux
+
+# Rust toolchain (rustup manages stable/nightly toolchains).
+# After install, `rustup default stable` to pull rustc/cargo.
+brew install rustup
+"$(brew --prefix)/opt/rustup/bin/rustup" default stable


### PR DESCRIPTION
## Summary

Adds Rust to the macOS setup. Useful for:
- \`cargo install\` of CLI tools
- The "build from source" fallback path inside \`tmux-agent-sidebar\`'s install wizard
- Hacking on any local Rust project

Using \`rustup\` (via Homebrew) instead of \`brew install rust\` because rustup gives us toolchain channels (stable / nightly) and \`rustup-managed\` components like rustfmt, clippy, rust-analyzer.

## Changes

- \`mac_install.sh\`: \`brew install rustup\` → \`rustup default stable\`
- \`.zshrc\`: prepend \`/opt/homebrew/opt/rustup/bin\` to \`PATH\` so \`cargo\` / \`rustc\` resolve

## Test plan

- [x] \`rustc --version\` → \`rustc 1.95.0\`
- [x] \`cargo --version\` → \`cargo 1.95.0\`
- [x] \`rustup show\` lists \`stable-aarch64-apple-darwin\` as default