### PR TITLE
tmux: tune pane layout defaults

### DIFF
--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -70,6 +70,7 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'hiroppy/tmux-agent-sidebar'
+set -g @sidebar_width 25%
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -28,6 +28,9 @@ bind | split-window -h
 # - でペインを横に分割する(下 pane は 40% 高で開く)
 bind - split-window -v -l 40%
 
+# prefix + c: 新 window を作る + 下 40% に補助 shell pane を最初から split
+bind c new-window \; split-window -v -l 40% \; select-pane -U
+
 # ウィンドウを消したときに、自動で番号を詰める
 set -g renumber-windows on
 

--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -25,8 +25,8 @@ bind r source-file ~/.tmux.conf \; display "Reloaded!"
 # | でペインを縦に分割する
 bind | split-window -h
 
-# - でペインを横に分割する
-bind - split-window -v
+# - でペインを横に分割する(下 pane は 40% 高で開く)
+bind - split-window -v -l 40%
 
 # ウィンドウを消したときに、自動で番号を詰める
 set -g renumber-windows on


### PR DESCRIPTION
## Summary
- Set `tmux-agent-sidebar` width to 25% so the sidebar pane occupies a sensible portion of the screen.
- Tweak `prefix + -` so the new bottom pane opens at 40% height.
- Override `prefix + c` to spawn a new window with a 40%-height bottom shell pane pre-split.

## Test plan
- [ ] `prefix + r` to reload, then verify `prefix + -` opens a 40% bottom pane.
- [ ] `prefix + c` opens a new window already split with the bottom pane sized to 40%.
- [ ] `prefix + e` toggles the sidebar at 25% width.