### PR TITLE
claude: clickable notification that jumps to originating tmux pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,30 @@ bash mac_install.sh
 - Ghostty (cask; font is macOS built-in Monaco)
 - [`workmux`](https://github.com/raine/workmux) — git worktree + tmux window orchestrator
 - [`tmux-agent-sidebar`](https://github.com/hiroppy/tmux-agent-sidebar) — sidebar that tracks Claude Code / Codex / OpenCode panes (installed via `tpm`)
+- [`terminal-notifier`](https://github.com/julienXX/terminal-notifier) — used by the Claude Code hook below to fire clickable macOS notifications
 - Config files:
   - `~/.zshrc`
   - `~/.vimrc`
   - `~/.tmux.conf` (from `tmux/2.9/`)
   - `~/.config/ghostty/config`
   - `~/.docker/config.json`
+  - `~/.claude/hooks/click-to-pane-notify.sh` (clickable notification → jumps Ghostty to the originating tmux pane)
+
+## Claude Code hooks (manual wiring)
+
+`mac_install.sh` drops the script in `~/.claude/hooks/`, but `~/.claude/settings.json` is hand-edited to wire it up. Add the following under `hooks`:
+
+```json
+"Stop":              [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/click-to-pane-notify.sh stop" }] }],
+"Notification":      [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/click-to-pane-notify.sh notification" }] }],
+"StopFailure":       [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/click-to-pane-notify.sh stop_failure" }] }],
+"PermissionDenied":  [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/click-to-pane-notify.sh permission_denied" }] }]
+```
+
+First-run notes:
+
+- macOS shows a notification permission prompt the first time `terminal-notifier` fires. Allow it under System Settings → Notifications.
+- `tmux-agent-sidebar` ships its own desktop notifications; the dotfiles `.tmux.conf` sets `@sidebar_notifications off` so this hook is the only source.
 - NeoBundle for Vim (under `~/.vim/bundle/`)
 - `emacs-digdag-mode` (under `~/.emacs.d/`)
 

--- a/claude/hooks/click-to-pane-notify.sh
+++ b/claude/hooks/click-to-pane-notify.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# クリック可能な macOS 通知を出して、クリック時にこの hook が動いた tmux pane に
+# Ghostty 越しでジャンプさせる。
+#
+# Usage: click-to-pane-notify.sh <event-name>
+#   event-name: stop | stop_failure | notification | permission_denied | ...
+#
+# stdin: Claude Code hook の JSON payload
+set -uo pipefail
+
+EVENT="${1:-stop}"
+PAYLOAD=$(cat 2>/dev/null || true)
+
+extract_field() {
+  local field="$1"
+  command -v jq >/dev/null 2>&1 || { echo ""; return; }
+  jq -r --arg f "$field" '.[$f] // empty' <<<"$PAYLOAD" 2>/dev/null || echo ""
+}
+
+case "$EVENT" in
+  stop)              DEFAULT_BODY="完了しました" ;;
+  stop_failure)      DEFAULT_BODY="エラー終了" ;;
+  notification)      DEFAULT_BODY="権限要求/確認待ち" ;;
+  permission_denied) DEFAULT_BODY="権限が拒否されました" ;;
+  *)                 DEFAULT_BODY="$EVENT" ;;
+esac
+
+BODY=$(extract_field message)
+[[ -z "$BODY" ]] && BODY="$DEFAULT_BODY"
+
+PANE_ID="${TMUX_PANE:-}"
+TITLE="Claude Code"
+SUBTITLE=""
+EXECUTE_CMD=""
+
+if [[ -n "$PANE_ID" ]] && command -v tmux >/dev/null 2>&1; then
+  SESSION=$(tmux display-message -p -t "$PANE_ID" '#{session_name}' 2>/dev/null || echo "")
+  WINDOW=$(tmux display-message -p -t "$PANE_ID" '#{window_index}' 2>/dev/null || echo "")
+  SUBTITLE="${SESSION}:${WINDOW} (${PANE_ID})"
+  # クリック時: Ghostty を前面に出してから、対象 session/window/pane を選択
+  EXECUTE_CMD="/usr/bin/open -a Ghostty; /opt/homebrew/bin/tmux switch-client -t '${SESSION}'; /opt/homebrew/bin/tmux select-window -t '${PANE_ID}'; /opt/homebrew/bin/tmux select-pane -t '${PANE_ID}'"
+fi
+
+ARGS=(
+  -title "$TITLE"
+  -message "$BODY"
+  -sound default
+)
+[[ -n "$SUBTITLE" ]] && ARGS+=( -subtitle "$SUBTITLE" )
+[[ -n "$EXECUTE_CMD" ]] && ARGS+=( -execute "$EXECUTE_CMD" )
+
+/opt/homebrew/bin/terminal-notifier "${ARGS[@]}" >/dev/null 2>&1 || true
+exit 0

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -47,6 +47,12 @@ brew install pnpm
 # - workmux: git worktree + tmux window orchestrator
 brew install raine/workmux/workmux
 
+# terminal-notifier: クリック可能な macOS 通知 (Claude Code hook から呼ぶ)
+brew install terminal-notifier
+
+# Claude Code 用 hook script (Stop 等の通知でクリック→該当 pane へジャンプ)
+install -D ./claude/hooks/click-to-pane-notify.sh ~/.claude/hooks/click-to-pane-notify.sh
+
 # Rust toolchain (rustup manages stable/nightly toolchains).
 # After install, `rustup default stable` to pull rustc/cargo.
 brew install rustup

--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -74,6 +74,8 @@ set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'hiroppy/tmux-agent-sidebar'
 set -g @sidebar_width 25%
+# 通知は Claude Code hook 経由(クリックで該当 pane に飛べる)に寄せるため OFF
+set -g @sidebar_notifications off
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
- Add `claude/hooks/click-to-pane-notify.sh`: macOS `terminal-notifier` wrapper that captures the originating tmux pane and runs `tmux switch-client + select-window + select-pane` plus `open -a Ghostty` on click.
- Update `mac_install.sh` to `brew install terminal-notifier` and drop the hook script under `~/.claude/hooks/`.
- Disable `tmux-agent-sidebar`'s built-in notifications (`@sidebar_notifications off`) so this hook becomes the single source of truth.
- Document the manual `~/.claude/settings.json` wiring + first-run permission steps in `README.md`.

## Notes
- `~/.claude/settings.json` is intentionally **not** committed; per-machine wiring is described in the README.
- `terminal-notifier` 2.0.0 + macOS Tahoe needs to be launched once (via `open .../terminal-notifier.app`) to register itself with Notification Center; passing `-sender` silently drops notifications on the same combo, so the hook avoids it.

## Test plan
- [ ] Fresh checkout: `bash mac_install.sh` installs terminal-notifier and lays down the hook.
- [ ] After wiring `~/.claude/settings.json`, hitting Claude Code's Stop event produces a clickable notification.
- [ ] Clicking the notification brings Ghostty forward and focuses the originating session/window/pane.
- [ ] No duplicate notification fires from `tmux-agent-sidebar`.