### PR TITLE
claude: ship settings.json as a templated install

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,9 @@ bash mac_install.sh
   - `~/.config/ghostty/config`
   - `~/.docker/config.json`
   - `~/.claude/hooks/click-to-pane-notify.sh` (clickable notification → jumps Ghostty to the originating tmux pane)
+  - `~/.claude/settings.json` (generated from `claude/settings.json`; `__HOME__` placeholder is replaced with `$HOME` at install time. Existing file is backed up to `settings.json.bak`.)
 
-## Claude Code hooks (manual wiring)
-
-`mac_install.sh` drops the script in `~/.claude/hooks/`, but `~/.claude/settings.json` is hand-edited to wire it up. Add the following under `hooks`:
-
-```json
-"Stop":              [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/click-to-pane-notify.sh stop" }] }],
-"Notification":      [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/click-to-pane-notify.sh notification" }] }],
-"StopFailure":       [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/click-to-pane-notify.sh stop_failure" }] }],
-"PermissionDenied":  [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash ~/.claude/hooks/click-to-pane-notify.sh permission_denied" }] }]
-```
-
-First-run notes:
+## Claude Code notification hook — first-run notes
 
 - macOS shows a notification permission prompt the first time `terminal-notifier` fires. Allow it under System Settings → Notifications.
 - `tmux-agent-sidebar` ships its own desktop notifications; the dotfiles `.tmux.conf` sets `@sidebar_notifications off` so this hook is the only source.
@@ -53,6 +43,7 @@ First-run notes:
 ├── .emacs.d/       # Emacs init.el
 ├── .vimrc
 ├── .zshrc
+├── claude/         # → ~/.claude/ (hooks + settings.json template)
 ├── ghostty/        # → ~/.config/ghostty/
 ├── tmux/2.9/       # → ~/.tmux.conf (tmux 2.9+)
 └── mac_install.sh

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,70 @@
+{
+  "permissions": {
+    "defaultMode": "auto"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/click-to-pane-notify.sh stop"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/click-to-pane-notify.sh notification"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/click-to-pane-notify.sh stop_failure"
+          }
+        ]
+      }
+    ],
+    "PermissionDenied": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/click-to-pane-notify.sh permission_denied"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "example-skills@anthropic-agent-skills": true,
+    "tmux-agent-sidebar@hiroppy": true
+  },
+  "extraKnownMarketplaces": {
+    "anthropic-agent-skills": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/skills"
+      }
+    },
+    "hiroppy": {
+      "source": {
+        "source": "directory",
+        "path": "__HOME__/.tmux/plugins/tmux-agent-sidebar"
+      }
+    }
+  },
+  "skipAutoPermissionPrompt": true
+}

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -53,6 +53,12 @@ brew install terminal-notifier
 # Claude Code 用 hook script (Stop 等の通知でクリック→該当 pane へジャンプ)
 install -D ./claude/hooks/click-to-pane-notify.sh ~/.claude/hooks/click-to-pane-notify.sh
 
+# Claude Code settings.json (テンプレ内 __HOME__ を実 $HOME に展開して配置)
+# 既存ファイルがあれば .bak に退避してから上書き
+mkdir -p ~/.claude
+[ -f ~/.claude/settings.json ] && cp ~/.claude/settings.json ~/.claude/settings.json.bak
+sed "s|__HOME__|${HOME}|g" ./claude/settings.json > ~/.claude/settings.json
+
 # Rust toolchain (rustup manages stable/nightly toolchains).
 # After install, `rustup default stable` to pull rustc/cargo.
 brew install rustup


### PR DESCRIPTION
## Summary
- Add `claude/settings.json` template that wires the click-to-pane notification hook, enabled plugins, and `extraKnownMarketplaces`. Local-only paths use a `__HOME__` placeholder for portability.
- `mac_install.sh` runs `sed s|__HOME__|$HOME|g` and writes `~/.claude/settings.json` (existing file backed up to `settings.json.bak`).
- Drop the now-obsolete "manual wiring" section from the README; document the install behaviour and first-run notes instead.

## Notes
- `skipDangerousModePermissionPrompt` is intentionally **not** committed. `bypassPermissions` mode hasn't been used in over a month; if it ever comes back, accepting the one-time prompt is fine.
- `extraKnownMarketplaces.*.source.path` does not expand `~`/`$HOME` (per Claude Code GitHub issue #23978), which is why the template substitutes at install time.
- No secrets or company-internal data committed.

## Test plan
- [ ] Fresh checkout: `bash mac_install.sh` installs `~/.claude/settings.json` with `$HOME` resolved correctly.
- [ ] Re-run on an existing machine backs up the old settings.json to `.bak`.
- [ ] Claude Code starts in auto mode and fires the click-to-pane notification on Stop.