### PR TITLE
chore(emacs): init.el phase B cleanup

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -27,7 +27,7 @@
 (setq auto-save-default nil)
 (setq delete-auto-save-files t)
 (setq-default show-trailing-whitespace t)
-(fset 'yes-or-no-p 'y-or-n-p)
+(setq use-short-answers t)
 (add-hook 'before-save-hook
           (lambda ()
             (delete-trailing-whitespace)))

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -17,8 +17,11 @@
 (prefer-coding-system 'utf-8)
 
 ;; Common settings
-(require 'smartparens-config)
-(smartparens-global-mode t)
+(use-package smartparens
+  :ensure t
+  :config
+  (require 'smartparens-config)
+  (smartparens-global-mode t))
 (setq inhibit-startup-message t)
 (setq make-backup-files nil)
 (setq auto-save-default nil)

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -128,6 +128,7 @@
 (use-package undo-tree
   :config
   (global-undo-tree-mode))
+(setq undo-tree-auto-save-history nil)
 (require 'dired-x)
 (require 'ido)
 (ido-mode t)
@@ -295,11 +296,10 @@
  ;; If you edit it by hand, you could mess it up, so be careful.
  ;; Your init file should contain only one such instance.
  ;; If there is more than one, they won't work right.
- '(flymake-python-pyflakes-extra-arguments (quote ("--max-line-length=120" "--ignore=E128")))
+ '(flymake-python-pyflakes-extra-arguments '("--max-line-length=120" "--ignore=E128"))
  '(org-agenda-files nil)
  '(package-selected-packages
-   (quote
-    (swiper company flycheck cargo company-jedi jedi xclip wgrep web-mode use-package undo-tree tabbar sql-indent slim-mode ruby-electric rubocop robe reverse-theme racer quickrun python-mode py-autopep8 package-utils markdown-mode magit js2-refactor js2-highlight-vars hive go-mode format-all flymake-python-pyflakes flycheck-pyflakes flycheck-pycheckers elpy dockerfile-mode docker-compose-mode ctags-update counsel-etags color-moccur auto-highlight-symbol all-the-icons-ivy))))
+   '(json-mode terraform-mode graphql-mode swiper company flycheck cargo company-jedi jedi xclip wgrep web-mode use-package undo-tree tabbar sql-indent slim-mode ruby-electric rubocop robe reverse-theme racer quickrun python-mode py-autopep8 package-utils markdown-mode magit js2-refactor js2-highlight-vars hive go-mode format-all flymake-python-pyflakes flycheck-pyflakes flycheck-pycheckers elpy dockerfile-mode docker-compose-mode ctags-update counsel-etags color-moccur auto-highlight-symbol all-the-icons-ivy)))
 
 ;; Install any selected packages that aren't present yet (skips network
 ;; refresh unless something is actually missing).

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -323,10 +323,6 @@
   '((:command . "python3"))
   :override t)
 
-;; digdag-mode settings
-(add-to-list 'load-path "~/.emacs.d/github/emacs-digdag-mode")
-(use-package digdag-mode)
-
 ;; sql-mode settings (including *.sql.template)
 (add-to-list 'auto-mode-alist '("\\.sql\\.*" . sql-mode))
 

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -276,17 +276,14 @@
 
 ;; ruby-mode settings
 (setq ruby-insert-encoding-magic-comment nil)
-(autoload 'ruby-mode "ruby-mode"
-  "Mode for editing ruby source files" t)
 (add-to-list 'auto-mode-alist '("\\.rb$" . ruby-mode))
 (add-to-list 'auto-mode-alist '("Capfile$" . ruby-mode))
 (add-to-list 'auto-mode-alist '("Gemfile$" . ruby-mode))
 (add-to-list 'auto-mode-alist '("[Rr]akefile$" . ruby-mode))
 (use-package auto-highlight-symbol)
 (global-auto-highlight-symbol-mode t)
-(autoload 'robe-mode "robe" "Code navigation, documentation lookup and completion for Ruby" t nil)
-(autoload 'robe-ac-setup "robe-ac" "robe auto-complete" nil nil)
-(add-hook 'robe-mode-hook 'robe-ac-setup)
+(use-package robe
+  :hook (robe-mode . robe-ac-setup))
 
 ;; python-mode settings
 (use-package python-mode)

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -287,7 +287,7 @@
 
 ;; python-mode settings
 (use-package python-mode)
-(add-hook 'python-mode-hook (lambda () (auto-complete-mode nil)))
+(add-hook 'python-mode-hook (lambda () (auto-complete-mode -1)))
 (use-package jedi)
 (setq jedi:complete-on-dot t)
 (setq jedi:use-shortcuts t)

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -15,7 +15,6 @@ brew install --cask ghostty
 
 # install Emacs (with cocoa)
 brew install --cask emacs
-git clone git@github.com:syohex/emacs-digdag-mode.git ~/.emacs.d/github.com/
 install ./.emacs.d/init.el ~/.emacs.d/
 
 # settings


### PR DESCRIPTION
## Summary

Phase B of the Emacs init.el refactor — drift reconciliation between dotfiles and the live ~/.emacs.d/init.el, plus a small modernization pass deferred from Phase A.

- Absorb live drift: undo-tree-auto-save-history nil, json/terraform/graphql additions, modern `'(...)` quoting in custom-set-variables
- Drop the digdag-mode block (no longer used) and the matching syohex/emacs-digdag-mode clone from mac_install.sh
- Wrap smartparens-config inside a proper smartparens use-package form (smartparens-config is a feature, not a package)
- Replace `(fset 'yes-or-no-p 'y-or-n-p)` with `(setq use-short-answers t)` (Emacs 28+)
- Drop redundant autoload forms for built-in ruby-mode and self-autoloading robe; switch robe to :hook
- Fix `(auto-complete-mode nil)` → `-1` in python-mode-hook (same trap as electric-indent-local-mode)

## Test plan

- [ ] emacs --daemon starts cleanly (only the benign hippie-expand redefine note remains)
- [ ] yes/no prompts answered with y/n
- [ ] smartparens still active in buffers
- [ ] python buffers do not enable auto-complete-mode