### PR TITLE
chore(emacs): init.el phase C cleanup

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -1,3 +1,7 @@
+;; Suppress the legacy advice-system note fired when packages re-defun
+;; an already-adviced function (e.g. hippie-expand during daemon start).
+(setq ad-redefinition-action 'accept)
+
 (require 'package)
 (add-to-list 'package-archives '("gnu"          . "https://elpa.gnu.org/packages/") t)
 (add-to-list 'package-archives '("melpa"        . "https://melpa.org/packages/") t)

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -35,7 +35,6 @@
 (add-hook 'before-save-hook
           (lambda ()
             (delete-trailing-whitespace)))
-;;              (indent-region (point-min) (point-max)) nil))
 
 ;; Keyboard settings
 (setq kill-whole-line t)
@@ -271,13 +270,6 @@
 (global-set-key (kbd "C-x C-q") 'quickrun)
 (global-set-key (kbd "C-x C-Q") 'quickrun-with-arg)
 
-;; if you use python3 command and use python command for python2
-;; (quickrun-add-command "python"
-;;   '((:command . "python3")
-;;     (:exec . "%c %s")
-;;     (:compile-only . "pyflakes %s"))
-;;   :mode 'python-mode)
-
 ;; ruby-mode settings
 (setq ruby-insert-encoding-magic-comment nil)
 (add-to-list 'auto-mode-alist '("\\.rb$" . ruby-mode))
@@ -357,23 +349,6 @@
 (global-set-key (kbd "C-c b") 'org-switchb)
 (global-set-key (kbd "C-c n") 'org-insert-heading-respect-content)
 
-;; if you use GUI
-;; (defun my-fullscreen ()
-;;   (interactive)
-;;   (set-frame-parameter nil 'fullscreen 'fullboth))
-
-;; (defun my-non-fullscreen ()
-;;   (interactive)
-;;   (set-frame-parameter nil 'width 82)
-;;   (set-frame-parameter nil 'fullscreen 'fullheight))
-
-;; (defun toggle-fullscreen ()
-;;   (interactive)
-;;   (if (eq (frame-parameter nil 'fullscreen) 'fullboth)
-;;       (my-non-fullscreen)
-;;     (my-fullscreen)))
-
-;; (global-set-key (kbd "<f2>") 'toggle-fullscreen)
 (custom-set-faces
  ;; custom-set-faces was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.


### PR DESCRIPTION
## Summary

Phase C — small cosmetic pass to retire the last cruft after Phase A/B.

- Silence the legacy advice 'got redefined' note printed on daemon start via `(setq ad-redefinition-action 'accept)`
- Drop commented-out dead code: the stray indent-region tail inside before-save-hook, the unused quickrun python3 example, and the GUI fullscreen toggle block

Custom company-complete-common2 / company--insert-candidate2 TAB tweaks were audited and intentionally kept — they implement a "TAB advances when the only candidate equals the prefix" UX that isn't matched by stock company-mode.

## Test plan

- [ ] emacs --daemon: only `[yas]` info note remains; no hippie-expand redefine line
- [ ] TAB completion behavior unchanged in code buffers