### PR TITLE
chore(emacs): lower yas-verbosity

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -112,6 +112,7 @@
 (use-package dockerfile-mode)
 (use-package docker-compose-mode)
 (use-package yasnippet)
+(setq yas-verbosity 2)
 (let ((snippets-dir (expand-file-name "~/.emacs.d/snippets")))
   (when (and (file-directory-p snippets-dir)
              (directory-files snippets-dir nil "^[^.]" t))


### PR DESCRIPTION
## Summary

Suppress the `[yas] Prepared just-in-time loading of snippets (but no snippets found).` info line on daemon start by setting `yas-verbosity` to 2 (warnings+errors).

## Test plan

- [ ] emacs --daemon prints no [yas] line