### PR TITLE
chore(emacs): lower yas-verbosity to 1

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -112,7 +112,7 @@
 (use-package dockerfile-mode)
 (use-package docker-compose-mode)
 (use-package yasnippet)
-(setq yas-verbosity 2)
+(setq yas-verbosity 1)
 (let ((snippets-dir (expand-file-name "~/.emacs.d/snippets")))
   (when (and (file-directory-p snippets-dir)
              (directory-files snippets-dir nil "^[^.]" t))


### PR DESCRIPTION
## Summary

Follow-up to #23. The 'no snippets found' line is emitted at level 2, not 3, so verbosity 2 was still letting it through. Drop to 1 (errors only) to fully silence it.

## Test plan

- [ ] emacs --daemon prints only `Starting Emacs daemon.`