### PR TITLE
chore: simplify tmux session setup

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -57,10 +57,8 @@ alias gl="git log"
 alias gb="git branch"
 
 # tmux settings
-alias tmnew="tmux new -s main"
-alias tsnew="tmux new -s sub"
-alias tm="tmux a -t main"
-alias ts="tmux a -t sub"
+alias tmnew="tmux new"
+alias tm="tmux a"
 
 # Emacs settings (Homebrew on Apple Silicon)
 alias emacsclient="/opt/homebrew/bin/emacsclient"

--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -43,26 +43,18 @@ set -as terminal-features ",xterm-ghostty:RGB,xterm-256color:RGB"
 
 # ステータスバーの色を設定する
 setw -g status-bg brightblue
-# setw -g status-bg brightred
-# setw -g status-bg green
 
 # status-left のフォーマットを指定する
-set-option -g status-left "#[fg=black,bg=brightblue] #S | "
-# set-option -g status-left "#[fg=black,bg=brightred] #S | "
-# set-option -g status-left "#[fg=black,bg=green] #S | "
+set-option -g status-left "#[fg=black,bg=brightblue] | "
 
 # ウィンドウリストの色を設定する
 setw -g window-status-style bg="brightblue",fg="black","dim"
-# setw -g window-status-style bg="brightred",fg="black","dim"
-# setw -g window-status-style bg="green",fg="black","dim"
 
 # アクティブなウィンドウを目立たせる
 setw -g window-status-current-style bg="red",fg="white","bright"
 
 # ペインボーダーの色を設定する
 set -g pane-border-style bg="black",fg="brightblue"
-# set -g pane-border-style bg="black",fg="brightred"
-# set -g pane-border-style bg="black",fg="green"
 
 # アクティブなペインを目立たせる
 set -g pane-active-border-style bg="yellow",fg="white"


### PR DESCRIPTION
## 概要

tmux を main/sub の 2 セッションに分けて運用していた名残を整理する。今は main 1 つしか使っておらず、`-s main` / `-s sub` で名前を付けて切り替える運用も不要になったため、セッション名前提のエイリアスや配色の使い分け前提のコメント類を削除する。

## 変更内容

- `tmux/2.9/.tmux.conf`
  - main/sub 色分け用に残していたコメントアウト済みの代替配色(brightred/green)を削除
  - ステータスバー左の `#S`（セッション名）表示を不要なので削除
- `.zshrc`
  - `tsnew` / `ts`（sub セッション用）エイリアスを削除
  - `tmnew` / `tm` を `-s main` / `-t main` 指定なしの単純な `tmux new` / `tmux a` に簡略化

## 動作確認

- [x] `mac_install.sh` で `.tmux.conf` / `.zshrc` を再配置して `tmux new` / `tmux a` が動くか確認
- [x] ステータスバーが想定通りの表示か確認