### PR TITLE
fix: improve vim cursorline contrast

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -20,6 +20,11 @@ let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
 colorscheme default
 hi Directory ctermfg=blue
 
+" cursorline はデフォルトの highlight だとシンタックス色とぶつかって読みづらいので
+" 暗めのグレー背景＋装飾なしに固定する
+hi CursorLine   cterm=NONE ctermbg=236 guibg=#3a3a3a
+hi CursorLineNr cterm=bold ctermbg=236 ctermfg=yellow guibg=#3a3a3a guifg=#ffd700
+
 "検索設定
 set ignorecase "大文字/小文字の区別なく検索する
 set smartcase "検索文字列に大文字が含まれている場合は区別して検索する


### PR DESCRIPTION
## 概要

`set cursorline` の効果でカーソル行の背景が明るくなり、シンタックスハイライトされた文字色（薄い blue/grey 系）とのコントラストが落ちて文字がほぼ読めなくなっていた問題を修正する。

## 変更内容

- `.vimrc`
  - `CursorLine` の背景色を暗いグレー (`guibg=#3a3a3a` / `ctermbg=236`) に固定し、`cterm=NONE` で下線等の装飾は無効化
  - `CursorLineNr` （カーソル行の行番号）も同じ背景色＋黄色の太字に変更して位置が分かりやすいようにする

## 動作確認

- [ ] markdown / コードファイルを開いて、カーソル行の文字が問題なく読めることを確認
- [ ] `set background=dark` の前提のため、ダーク前提で OK