### PR TITLE
chore: install rtk and run init for AI agents

### DIFF
--- a/mac_install.sh
+++ b/mac_install.sh
@@ -62,3 +62,19 @@ sed "s|__HOME__|${HOME}|g" ./claude/settings.json > ~/.claude/settings.json
 # After install, `rustup default stable` to pull rustc/cargo.
 brew install rustup
 "$(brew --prefix)/opt/rustup/bin/rustup" default stable
+
+# rtk (https://github.com/rtk-ai/rtk): CLI proxy that compresses tool output
+# before it reaches the LLM context. Install once, then wire it into each
+# AI tool's config via `rtk init`. Idempotent — re-running just re-applies
+# the hooks/config, so it's safe on a re-run of this script.
+brew install rtk
+rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g --gemini            # Gemini CLI
+rtk init -g --codex             # Codex (OpenAI)
+rtk init -g --agent cursor      # Cursor
+rtk init -g --agent windsurf    # Windsurf
+rtk init --agent cline          # Cline / Roo Code
+rtk init --agent kilocode       # Kilo Code
+rtk init --agent antigravity    # Google Antigravity
+rtk init -g --agent pi          # Pi
+rtk init --agent hermes         # Hermes


### PR DESCRIPTION
## 概要

`mac_install.sh` に [rtk](https://github.com/rtk-ai/rtk) のインストールと、README の Quick Start 通りの `rtk init` 一式を追加する。新しい mac をセットアップしたときに rtk のフックが自動で各 AI エージェントに対して有効化されるようにする。

## 変更内容

- `mac_install.sh`
  - `brew install rtk` を追加
  - README の Quick Start にある全 10 エージェント分の `rtk init` を順番に実行
    - Claude Code / Copilot, Gemini CLI, Codex, Cursor, Windsurf, Cline / Roo Code, Kilo Code, Antigravity, Pi, Hermes

未インストールのエージェントについても `rtk init` は config を生成するだけなので、後から導入したエージェントでも追加作業なしで rtk のフックが効くようにする狙い。

## 動作確認

- [ ] `mac_install.sh` を実行して `brew install rtk` と各 `rtk init` がエラーにならないこと
- [ ] `rtk --version` がインストールされたバージョンを返すこと
- [ ] 既存の各エージェント config（`~/.claude/settings.json` 等）が rtk のフックを参照するように更新されていること