### PR TITLE
fix(tmux): improve status bar readability for passive tabs and session name

### DIFF
--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -45,10 +45,11 @@ set -as terminal-features ",xterm-ghostty:RGB,xterm-256color:RGB"
 setw -g status-bg brightblue
 
 # status-left のフォーマットを指定する
-set-option -g status-left "#[fg=black,bg=brightblue] | "
+# session 名は黒地チップにして青いタブ列と視覚的に分離する
+set-option -g status-left "#[fg=brightblue,bg=black,bold] #S #[fg=black,bg=brightblue] "
 
-# ウィンドウリストの色を設定する
-setw -g window-status-style bg="brightblue",fg="black","dim"
+# ウィンドウリストの色を設定する(dim だと黒文字が bg に溶けるので外して純黒に)
+setw -g window-status-style bg="brightblue",fg="black"
 
 # アクティブなウィンドウを目立たせる(深い赤地 + 純白の太字でコントラストを確保。
 # 名前付き white は color7=薄いグレーなので RGB 指定で純白にする)


### PR DESCRIPTION
## 概要

ステータスバーの視認性をさらに改善します。今回は 2 点:

1. パッシブ window タブの文字が背景に溶けて見づらかった
2. session 名（`#S`）がパッシブタブと同じ配色で見分けづらかった

## 背景・変更内容

### 1. パッシブタブ: `dim` 属性を削除

`window-status-style` の `dim` 属性により黒文字が減光され、`brightblue` 背景に溶けてグレーがかって見えていた。`dim` を外して純黒にし、コントラストを確保する。

| | Before | After |
|---|--------|-------|
| パッシブタブ文字 | `black` + `dim` | `black` |

### 2. session 名: 黒地チップに分離

`status-left` の session 名が `fg=black, bg=brightblue` でパッシブタブと同一配色だったため、左端の session 名と window タブ列が混同しやすかった。session 名を黒地＋青文字の太字チップにして視覚的に分離する。あわせて、ローカルにはあったが dotfiles 側で欠けていた `#S`（session 名表示）を追加して統一する。

| | Before | After |
|---|--------|-------|
| status-left | `fg=black, bg=brightblue` (`#S` は dotfiles 側欠落) | `fg=brightblue, bg=black, bold` + `#S` 追加 |

## 結果

ステータスバーの 3 階層が明確に区別できる:

- **session**: 黒地・青文字（太字）
- **パッシブタブ**: 青地・黒文字
- **アクティブタブ**: 深赤地・白文字（太字, #29 で対応済み）

## 確認

ローカル `~/.tmux.conf` にも同変更を反映し `tmux source-file` でリロード済み。実機で視認性を確認した。