### PR TITLE
chore(ghostty): unify Claude Code / pi newline on Option+Enter

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -5,6 +5,10 @@ copy-on-select = clipboard
 # Option キーを Alt として送る(tmux の M-w 等に必要)
 macos-option-as-alt = left
 
+# Claude Code / pi の改行を Option+Enter で統一 (LF を送る)
+# macos-option-as-alt のデフォルト挙動(ESC+CR)を上書き
+keybind = alt+enter=text:\n
+
 # Font
 font-family = "Monaco"
 font-size = 14


### PR DESCRIPTION
## Summary

Unify the newline keybinding for both Claude Code and pi CLIs under `Option+Enter` in Ghostty.

## Background

Previously, `Option+Enter` worked for Claude Code (which accepts `ESC+CR` via `macos-option-as-alt = left`), but pi did not recognize it as a newline. As a workaround, `Shift+Enter` was temporarily bound to LF for pi, but having two different shortcuts for the same logical operation was inconvenient.

## Change

Add an explicit Ghostty keybind that sends a bare LF (`\\n`) on `Option+Enter`, overriding the default `macos-option-as-alt` behavior (`ESC+CR`):

```
keybind = alt+enter=text:\\n
```

Both Claude Code and pi accept LF as a newline, so a single shortcut now works across both CLIs.

## Verification

- [x] Claude Code: `Option+Enter` inserts a newline
- [x] pi: `Option+Enter` inserts a newline
- [x] Other Option-based shortcuts (e.g. tmux `M-w`) remain unaffected