### PR TITLE
feat(claude): manage global CLAUDE.md and imported docs in dotfiles

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,0 +1,2 @@
+@RTK.md
+@PR_WORKFLOW.md

--- a/claude/PR_WORKFLOW.md
+++ b/claude/PR_WORKFLOW.md
@@ -1,0 +1,33 @@
+# PR Workflow (applies to ALL repositories)
+
+When the user asks to create a PR, follow this workflow regardless of the repository.
+
+## Language
+
+- **All commit messages, PR titles, and PR descriptions MUST be written in English.**
+- This applies regardless of the language the user is conversing in.
+
+## Steps
+
+1. **Create a feature branch** off the default branch.
+2. **First commit MUST be an empty commit** with `--allow-empty`, whose message becomes the PR title.
+   - Use a Conventional Commits prefix: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, etc.
+   - Scope is encouraged: `feat(ghostty): ...`, `chore(tmux): ...`.
+   - Example: `git commit --allow-empty -m "feat(scope): short summary"`
+3. **Add real changes** in subsequent commits.
+   - **Keep commits as fine-grained as possible**: one logical change per commit.
+   - Prefer many small commits over one large commit; squash-merge will consolidate them on `master`.
+   - Each commit message also follows Conventional Commits.
+4. **Push** the branch to `origin`.
+5. **Create a draft PR** with `gh pr create --draft`.
+   - **Title**: same as the first empty commit message.
+   - **Description**: structured (e.g. Summary / Background / Change / Verification).
+6. **Mark the PR as ready for review** (`gh pr ready <num>`) without waiting for explicit approval.
+7. **Merge the PR** (`gh pr merge <num> --squash --delete-branch`) without waiting for explicit approval.
+8. **Return to the default branch** and pull (or confirm fast-forward).
+
+## Notes
+
+- This applies to every repository unless the user says otherwise for a specific case.
+- If the repository has a PR template, fill it in on top of the structure above (still in English).
+- If CI is configured and required, mention the status briefly after merge.

--- a/claude/RTK.md
+++ b/claude/RTK.md
@@ -1,0 +1,29 @@
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show command usage history with savings
+rtk discover          # Analyze Claude Code history for missed opportunities
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Installation Verification
+
+```bash
+rtk --version         # Should show: rtk X.Y.Z
+rtk gain              # Should work (not "command not found")
+which rtk             # Verify correct binary
+```
+
+⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
+
+## Hook-Based Usage
+
+All other commands are automatically rewritten by the Claude Code hook.
+Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+
+Refer to CLAUDE.md for full command reference.

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -67,6 +67,13 @@ mkdir -p ~/.claude
 [ -f ~/.claude/settings.json ] && cp ~/.claude/settings.json ~/.claude/settings.json.bak
 sed "s|__HOME__|${HOME}|g" ./claude/settings.json > ~/.claude/settings.json
 
+# Claude Code のグローバル指示ファイル (CLAUDE.md 及び @import されるドキュメント)を配置。
+# 既存ファイルは .bak に退避してから上書きする。
+for f in CLAUDE.md RTK.md PR_WORKFLOW.md; do
+  [ -f ~/.claude/"$f" ] && cp ~/.claude/"$f" ~/.claude/"$f".bak
+  cp ./claude/"$f" ~/.claude/"$f"
+done
+
 # Rust toolchain (rustup manages stable/nightly toolchains).
 # After install, `rustup default stable` to pull rustc/cargo.
 brew install rustup


### PR DESCRIPTION
## Summary

Track Claude Code's global instruction files (`~/.claude/*.md`) in this repository and install them as part of `mac_install.sh`, so the same global guidance follows the dotfiles to any new machine.

## Background

Claude Code reads `~/.claude/CLAUDE.md` on startup and follows any files it `@`-imports. Until now these files lived only on a single workstation, which meant:

- New machines started with an empty global instruction set.
- Updates to PR conventions or tooling docs were not version-controlled.
- There was no single source of truth for cross-repository workflow rules (e.g. PR workflow, rtk usage).

## Change

- Add `claude/CLAUDE.md` as the entry point that `@`-imports the other docs.
- Add `claude/RTK.md` describing rtk (Rust Token Killer) usage. The corresponding `brew install rtk` + `rtk init` steps already exist in `mac_install.sh`.
- Add `claude/PR_WORKFLOW.md` codifying the repository-agnostic PR workflow:
  - All commit messages, PR titles, and PR descriptions are written in English.
  - First commit is an empty Conventional Commits commit whose message becomes the PR title.
  - Real changes are split into fine-grained commits.
  - PRs are created as drafts, then marked ready and squash-merged.
- Extend `mac_install.sh` to copy these files into `~/.claude/`, backing up any existing file to `*.bak` (matching the existing pattern used for `settings.json`).

## Verification

- [x] `mac_install.sh` copies all three `.md` files into `~/.claude/`.
- [x] Existing `~/.claude/*.md` files are preserved as `*.bak` before being overwritten.
- [x] No machine-specific paths or secrets are embedded in the tracked files.