### PR TITLE
feat(pi): install yuku's pi extension set

### DIFF
--- a/mac_install.sh
+++ b/mac_install.sh
@@ -94,3 +94,10 @@ rtk init --agent kilocode       # Kilo Code
 rtk init --agent antigravity    # Google Antigravity
 rtk init -g --agent pi          # Pi
 rtk init --agent hermes         # Hermes
+
+# Pi (https://pi.dev/): customizable coding agent. Extensions are managed via
+# `pi install <source>`. The list below mirrors yuku's recommended set.
+# `pi install` is idempotent — re-running just refreshes the package.
+if command -v pi >/dev/null 2>&1; then
+  :
+fi

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -99,5 +99,6 @@ rtk init --agent hermes         # Hermes
 # `pi install <source>`. The list below mirrors yuku's recommended set.
 # `pi install` is idempotent — re-running just refreshes the package.
 if command -v pi >/dev/null 2>&1; then
-  :
+  # Anthropic Claude Pro/Max OAuth auth for Pi
+  pi install npm:pi-anthropic-oauth
 fi

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -103,4 +103,6 @@ if command -v pi >/dev/null 2>&1; then
   pi install npm:pi-anthropic-oauth
   # Codex-friendly tool set (diff-based edits, GPT image gen, web search)
   pi install npm:@howaboua/pi-codex-conversion
+  # Claude Code style subagents
+  pi install npm:@tintinweb/pi-subagents
 fi

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -101,4 +101,6 @@ rtk init --agent hermes         # Hermes
 if command -v pi >/dev/null 2>&1; then
   # Anthropic Claude Pro/Max OAuth auth for Pi
   pi install npm:pi-anthropic-oauth
+  # Codex-friendly tool set (diff-based edits, GPT image gen, web search)
+  pi install npm:@howaboua/pi-codex-conversion
 fi

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -111,4 +111,6 @@ if command -v pi >/dev/null 2>&1; then
   pi install npm:@juicesharp/rpiv-btw
   # Shopify's autonomous experiment loop driver
   pi install git:github.com/davebcn87/pi-autoresearch
+  # Codex-like /goal command
+  pi install git:github.com/fitchmultz/pi-codex-goal
 fi

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -105,4 +105,8 @@ if command -v pi >/dev/null 2>&1; then
   pi install npm:@howaboua/pi-codex-conversion
   # Claude Code style subagents
   pi install npm:@tintinweb/pi-subagents
+  # rpiv: research -> plan -> implement -> validate workflow
+  pi install npm:@juicesharp/rpiv-pi
+  pi install npm:@juicesharp/rpiv-ask-user-question
+  pi install npm:@juicesharp/rpiv-btw
 fi

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -109,4 +109,6 @@ if command -v pi >/dev/null 2>&1; then
   pi install npm:@juicesharp/rpiv-pi
   pi install npm:@juicesharp/rpiv-ask-user-question
   pi install npm:@juicesharp/rpiv-btw
+  # Shopify's autonomous experiment loop driver
+  pi install git:github.com/davebcn87/pi-autoresearch
 fi


### PR DESCRIPTION
## Summary

Add yuku's recommended set of Pi (https://pi.dev/) extensions to `mac_install.sh` so a fresh machine ends up with the same coding agent setup.

## Background

Pi is a customizable coding agent whose capabilities live almost entirely in extensions. Without scripting the installs, recreating a working environment on a new machine means manually running `pi install` for each package and remembering the exact source URLs. Tracking the install commands in `mac_install.sh` gives a single, idempotent reproduction path.

## Change

Append a Pi extensions block to `mac_install.sh` (guarded by `command -v pi` so the script is still safe on machines where Pi is not installed). The block installs:

- `pi-anthropic-oauth` \u2014 Anthropic Claude Pro/Max OAuth auth for Pi.
- `@howaboua/pi-codex-conversion` \u2014 Codex-friendly tool set (diff-based edits, GPT image generation, web search).
- `@tintinweb/pi-subagents` \u2014 Claude Code style subagents for Pi.
- `@juicesharp/rpiv-pi` + `@juicesharp/rpiv-ask-user-question` + `@juicesharp/rpiv-btw` \u2014 the rpiv research \u2192 plan \u2192 implement \u2192 validate workflow.
- `pi-autoresearch` (Shopify) \u2014 autonomous experiment loop driver.
- `pi-codex-goal` \u2014 Codex-like `/goal` command.

`pi-cmux` and `pi-memory-dreaming` were intentionally excluded per the operator's decision.

`pi install` is idempotent, so re-running `mac_install.sh` simply refreshes each package.

## Verification

- [x] `pi list` on the local machine shows all installed packages above.
- [x] The new block in `mac_install.sh` is wrapped in `if command -v pi >/dev/null 2>&1; then ... fi` so it no-ops when Pi is absent.
- [x] No machine-specific values are embedded.