### PR TITLE
chore(ghostty): brighten bright black palette for readable dim text

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -16,6 +16,10 @@ font-size = 14
 # Theme
 theme = "Catppuccin Mocha"
 
+# pi の "Working..." など dim gray で出るテキストが見づらいため
+# bright black (ANSI 8) を Catppuccin Mocha の Surface2 から Overlay1 に明るくする
+palette = 8=#7f849c
+
 # Shell integration (zsh) — プロンプト間ジャンプ・実行時間・exit status 等
 shell-integration = zsh
 shell-integration-features = cursor,sudo


### PR DESCRIPTION
## Summary

Override Ghostty's ANSI bright black (color 8) on top of the Catppuccin Mocha theme so dim gray status text \u2014 most visibly Pi's `Working...` indicator \u2014 stays readable.

## Background

Catppuccin Mocha sets ANSI bright black to `#585b70` (Surface2). Many TUIs, including Pi, render transient status text such as `Working...` using bright black, and on the default Mocha background it ends up almost invisible.

## Change

Add a single `palette` override after the theme line in `ghostty/config`:

```
palette = 8=#7f849c
```

`#7f849c` is Catppuccin Mocha's Overlay1, which is noticeably brighter than Surface2 while still reading as "dim" against the dark background. Other palette entries are left untouched, so colored output (errors, diffs, syntax highlighting) is unchanged.

## Verification

- [x] Pi's `Working...` text is clearly readable in the local Ghostty window.
- [x] Other dim/comment-style output is also more legible without overpowering primary text.
- [x] No other palette entries or theme settings were modified.