### PR TITLE
chore(pi): suppress startup warnings (anthropic, tmux extended-keys)

### DIFF
--- a/mac_install.sh
+++ b/mac_install.sh
@@ -124,7 +124,8 @@ if command -v pi >/dev/null 2>&1; then
     cp "$PI_SETTINGS" "$PI_SETTINGS.bak"
     tmp=$(mktemp)
     jq '.themes = ((.themes // []) + ["~/.pi/themes/dark-bright-dim.json"] | unique)
-        | .theme = "dark-bright-dim"' \
+        | .theme = "dark-bright-dim"
+        | .warnings = ((.warnings // {}) + {anthropicExtraUsage: false})' \
       "$PI_SETTINGS" > "$tmp" && mv "$tmp" "$PI_SETTINGS"
   fi
 fi

--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -41,6 +41,11 @@ set -g status-position top
 set -g default-terminal "tmux-256color"
 set -as terminal-features ",xterm-ghostty:RGB,xterm-256color:RGB"
 
+# Modified Enter (Shift+Enter / Option+Enter 等)を CSI u で透過させる。
+# pi などの CLI が修飾キーを検出できるようになる。
+set -g extended-keys on
+set -g extended-keys-format csi-u
+
 # ステータスバーの色を設定する
 setw -g status-bg brightblue
 


### PR DESCRIPTION
## Summary

Eliminate the two recurring Pi startup warnings:

1. `Anthropic subscription auth is active. Third-party harness usage draws from extra usage...`
2. `tmux extended-keys is off. Modified Enter keys may not work...`

## Background

The Anthropic warning is informational: we are intentionally using Claude Pro/Max OAuth via `pi-anthropic-oauth` and already understand the billing implications. The tmux warning fires because tmux does not have `extended-keys` turned on, which also blocks modified Enter keys (Option+Enter, Shift+Enter) from being delivered to Pi as distinct events.

## Change

- `tmux/2.9/.tmux.conf`: enable `extended-keys on` and `extended-keys-format csi-u` so modifier-aware Enter keys pass through tmux, and the warning stops firing.
- `mac_install.sh`: extend the `jq` patch that already manages Pi's theme to also set `warnings.anthropicExtraUsage = false` in `~/.pi/agent/settings.json`, suppressing the Anthropic subscription notice on every startup.

## Verification

- [x] After sourcing the new tmux conf, `tmux show -gv extended-keys` reports `on` and `extended-keys-format` reports `csi-u`.
- [x] After patching `~/.pi/agent/settings.json`, `jq '.warnings'` shows `{ "anthropicExtraUsage": false }`.
- [x] On the next Pi restart, neither warning is printed.
- [x] `mac_install.sh` is still idempotent: the `jq` merge preserves prior keys and overwrites only the targeted fields.