### PR TITLE
chore(claude): symlink global instruction md and document CodeRabbit review handling

### DIFF
--- a/claude/PR_WORKFLOW.md
+++ b/claude/PR_WORKFLOW.md
@@ -23,8 +23,21 @@ When the user asks to create a PR, follow this workflow regardless of the reposi
    - **Title**: same as the first empty commit message.
    - **Description**: structured (e.g. Summary / Background / Change / Verification).
 6. **Mark the PR as ready for review** (`gh pr ready <num>`) without waiting for explicit approval.
-7. **Merge the PR** (`gh pr merge <num> --squash --delete-branch`) without waiting for explicit approval.
-8. **Return to the default branch** and pull (or confirm fast-forward).
+7. **Handle the CodeRabbit review** (see the dedicated section below) before merging.
+8. **Merge the PR** (`gh pr merge <num> --squash --delete-branch`) without waiting for explicit approval.
+9. **Return to the default branch** and pull (or confirm fast-forward).
+
+## CodeRabbit review handling
+
+After the PR is ready, CodeRabbit posts an automated review. Address it before merging.
+
+- Wait for the review to finish (`gh pr checks <num>` shows CodeRabbit "Review completed"). List inline comments with `gh api repos/<owner>/<repo>/pulls/<num>/comments`.
+- Handle **each** inline comment individually:
+  - **If you address it**: make the fix in a **separate commit** (one logical fix per comment, Conventional Commits), push, then reply inline with `Fixed: <commit URL>` via `gh api repos/<owner>/<repo>/pulls/<num>/comments/<comment_id>/replies -f body=...`.
+  - **If you do NOT address it**: reply inline with a clear reason why it is intentionally skipped.
+- Commit fixes to the **same PR branch** — never open a separate PR for CodeRabbit fixes.
+- Inline replies may be written in the language of the review (Japanese is fine); commit messages / PR title / description stay English per the Language rule.
+- After all comments are handled and CI is green again, proceed to merge.
 
 ## Notes
 

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -68,11 +68,15 @@ mkdir -p ~/.claude
 [ -f ~/.claude/settings.json ] && cp ~/.claude/settings.json ~/.claude/settings.json.bak
 sed "s|__HOME__|${HOME}|g" ./claude/settings.json > ~/.claude/settings.json
 
-# Claude Code のグローバル指示ファイル (CLAUDE.md 及び @import されるドキュメント)を配置。
-# 既存ファイルは .bak に退避してから上書きする。
+# Claude Code のグローバル指示ファイル (CLAUDE.md 及び @import されるドキュメント)を symlink で配置。
+# 静的な md なので symlink にし、dotfiles 側を編集すれば即 ~/.claude に反映されるようにする。
+# 既存が実ファイル(非 symlink)なら一度だけ .bak に退避してから symlink を張る。リラン可。
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 for f in CLAUDE.md RTK.md PR_WORKFLOW.md; do
-  [ -f ~/.claude/"$f" ] && cp ~/.claude/"$f" ~/.claude/"$f".bak
-  cp ./claude/"$f" ~/.claude/"$f"
+  if [ -f ~/.claude/"$f" ] && [ ! -L ~/.claude/"$f" ]; then
+    cp ~/.claude/"$f" ~/.claude/"$f".bak
+  fi
+  ln -sf "${DOTFILES_DIR}/claude/$f" ~/.claude/"$f"
 done
 
 # Rust toolchain (rustup manages stable/nightly toolchains).


### PR DESCRIPTION
## Summary

Claude Code のグローバル指示 md を symlink 配置に変更し、PR ワークフローに CodeRabbit レビュー対応手順を追記する。

## Background

- `~/.claude/{CLAUDE,RTK,PR_WORKFLOW}.md` は `mac_install.sh` で copy 配置していたため、dotfiles を編集しても再インストールするまで `~/.claude` に反映されなかった。
- PR ワークフローに CodeRabbit レビューの標準対応手順が無く、毎回アドホックだった。

## Change

- `mac_install.sh`: 上記3つの静的 md を copy → **symlink**（`~/.claude/X` → `dotfiles/claude/X`）。既存の実ファイルは一度だけ `.bak` 退避。idempotent。
  - `settings.json`（`__HOME__` 展開）と hooks（chmod 要）は copy のまま据え置き。
- `claude/PR_WORKFLOW.md`: 「CodeRabbit review handling」節を追加（Step 7 として挿入）。指摘ごとに別コミットで対応し `Fixed: <commit URL>` を inline 返信、未対応は理由を返信、同一 PR ブランチに集約。

## Verification

- ローカルで symlink 適用済み（`~/.claude/PR_WORKFLOW.md` → dotfiles を確認、内容に CodeRabbit 節が反映）。
- `mac_install.sh` の変更はリラン安全（symlink は `ln -sf`、実ファイルのみ `.bak` 退避）。
