### PR TITLE
chore(claude): generalize bot review handling in PR_WORKFLOW

### DIFF
--- a/claude/PR_WORKFLOW.md
+++ b/claude/PR_WORKFLOW.md
@@ -23,20 +23,21 @@ When the user asks to create a PR, follow this workflow regardless of the reposi
    - **Title**: same as the first empty commit message.
    - **Description**: structured (e.g. Summary / Background / Change / Verification).
 6. **Mark the PR as ready for review** (`gh pr ready <num>`) without waiting for explicit approval.
-7. **Handle the CodeRabbit review** (see the dedicated section below) before merging.
+7. **Handle automated bot reviews** (see the dedicated section below) before merging.
 8. **Merge the PR** (`gh pr merge <num> --squash --delete-branch`) without waiting for explicit approval.
 9. **Return to the default branch** and pull (or confirm fast-forward).
 
-## CodeRabbit review handling
+## Automated bot review handling
 
-After the PR is ready, CodeRabbit posts an automated review. Address it before merging.
+After the PR is ready, automated review bots (CodeRabbit, Copilot for PRs, Greptile, Sweep, etc.) may post inline comments. Address every such bot review uniformly using the protocol below before merging.
 
-- Wait for the review to finish (`gh pr checks <num>` shows CodeRabbit "Review completed"). List inline comments with `gh api repos/<owner>/<repo>/pulls/<num>/comments`.
+- Wait for each bot's review to finish (`gh pr checks <num>` typically shows the bot's status). List inline comments with `gh api repos/<owner>/<repo>/pulls/<num>/comments`.
 - Handle **each** inline comment individually:
   - **If you address it**: make the fix in a **separate commit** (one logical fix per comment, Conventional Commits), push, then reply inline with `Fixed: <commit URL>` via `gh api repos/<owner>/<repo>/pulls/<num>/comments/<comment_id>/replies -f body=...`.
   - **If you do NOT address it**: reply inline with a clear reason why it is intentionally skipped.
-- Commit fixes to the **same PR branch** — never open a separate PR for CodeRabbit fixes.
+- Commit fixes to the **same PR branch** — never open a separate PR for bot-feedback fixes.
 - Inline replies may be written in the language of the review (Japanese is fine); commit messages / PR title / description stay English per the Language rule.
+- This protocol applies to every automated review bot, not just CodeRabbit. If a new bot is enabled on the repository, treat its inline comments the same way.
 - After all comments are handled and CI is green again, proceed to merge.
 
 ## Notes


### PR DESCRIPTION
## Summary

Generalize the CodeRabbit-specific section of `claude/PR_WORKFLOW.md` so the same protocol (inline reply per comment, `Fixed: <commit URL>` for addressed items, skip-with-reason otherwise) applies uniformly to **every** automated review bot — CodeRabbit, Copilot for PRs, Greptile, Sweep, etc.

## Background

The workflow was written when CodeRabbit was the only inline-review bot we used, so the rules were phrased as "CodeRabbit review handling". As more repos enable other bots (Copilot for PRs, Greptile, ...), the handling protocol should not be re-derived per bot — it is identical for all.

## Change

- Rename section to "Automated bot review handling"
- Reword steps so they apply to any bot, not just CodeRabbit
- Add an explicit statement that new bots adopted on a repo are handled the same way
- Step 7 wording in "Steps" updated to match

## Verification

- Diff is text-only in `claude/PR_WORKFLOW.md`.
- No tooling or schema changes.