### PR TITLE
fix(zshrc): force emacs keymap so Ctrl-P / Ctrl-N navigate history

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -4,6 +4,11 @@ compinit
 autoload -Uz colors
 colors
 
+# Pin the emacs keymap. With EDITOR=vim set, zsh auto-selects the vi
+# keymap where ^P / ^N fall through to self-insert instead of moving
+# through history — force emacs to keep the readline-style bindings.
+bindkey -e
+
 setopt COMPLETE_IN_WORD
 
 # Prompt settings


### PR DESCRIPTION
## 概要

Ghostty 上のシェルプロンプトで `Ctrl-P` / `Ctrl-N` が history navigation として効かず、`^P` / `^N` がリテラル入力（`self-insert`）されてしまう問題を修正する。

## 原因

- `.zshrc` に明示的な `bindkey -e` が無い
- 環境変数 `EDITOR=vim` / `VISUAL=vim` が設定されているため、zsh が自動判定で vi keymap を選択する
- vi keymap では `^P` / `^N` は `self-insert` にフォールバックする

`bindkey | grep '"\^P"'` を打つと `"^N"-"^P" self-insert` と出るのが決定的な証拠。

## 変更内容

- `.zshrc`: 冒頭付近で `bindkey -e` を明示

## 動作確認

- [ ] シェル再起動後、`bindkey | grep '"\^P"'` が `"^P" up-line-or-history` を返すこと
- [ ] プロンプトで `Ctrl-P` を押すと直近のコマンドが呼び出されること
- [ ] `Ctrl-N` で次のコマンドに進めること
- [ ] `^R` (`zaw-history`) など既存の bindkey に影響がないこと