### PR TITLE
fix(tmux): pin emacs mode-keys so Alt-V page-up works in copy-mode

### DIFF
--- a/tmux/2.9/.tmux.conf
+++ b/tmux/2.9/.tmux.conf
@@ -8,6 +8,11 @@ unbind C-b
 # キーストロークのディレイを減らす
 set -sg escape-time 1
 
+# Pin the emacs copy-mode key bindings. tmux(1) auto-selects vi when
+# $EDITOR / $VISUAL contains "vi" — this repo sets EDITOR=vim so that
+# path kicks in and disables M-v / C-v page-up / page-down.
+set -g mode-keys emacs
+
 # OSC 52 でシステムクリップボードにコピーする
 set -g set-clipboard on
 


### PR DESCRIPTION
## 概要

tmux の copy-mode で `Alt-V`（page-up）が効かない問題を修正する。zshrc で発覚した [[emacs 強制]] と同じ根っこで、tmux 本体が `$EDITOR` / `$VISUAL` に "vi" を含む場合に `mode-keys` を vi に自動選択していた。vi モードでは `M-v` は未 bind なのでログを遡れない。

## 原因

- `.tmux.conf` に `mode-keys` の明示指定が無い
- tmux(1) の manpage 通り、`$EDITOR` または `$VISUAL` に "vi" が含まれると `mode-keys` の default が vi になる
- この repo は `EDITOR=vim` を設定しているので、`tmux show -gv mode-keys` は `vi` を返す
- vi モードでは page-up は `Ctrl-U`/`Ctrl-B` 系で、emacs 慣習の `M-v` は未 bind

（当初 tmux-sensible の仕業と誤診断したが、tmux-sensible には `mode-keys` を触るコードは無いことを確認済み）

## 変更内容

- `tmux/2.9/.tmux.conf`
  - 冒頭付近（`set -sg escape-time 1` の直後）に `set -g mode-keys emacs` を追加

## 動作確認

- [x] `tmux source-file ~/.tmux.conf && tmux show -gv mode-keys` が `emacs` を返すこと
- [ ] `prefix + [` で copy-mode に入り `Alt-V` で page-up、`Ctrl-V` で page-down できること
- [ ] 既存の `prefix + Up/Down`（プロンプト間ジャンプ）に regression が無いこと