### PR TITLE
chore(mac_install): enable git rebase.updateRefs globally

### DIFF
--- a/mac_install.sh
+++ b/mac_install.sh
@@ -133,3 +133,9 @@ if command -v pi >/dev/null 2>&1; then
       "$PI_SETTINGS" > "$tmp" && mv "$tmp" "$PI_SETTINGS"
   fi
 fi
+
+# Git: enable --update-refs by default. With this on, `git rebase` advances
+# every stacked / intermediate branch ref that sits on the range being
+# rebased, so stacked-branch workflows don't need `--update-refs` on each
+# invocation. Idempotent — re-running just re-sets the same key.
+git config --global rebase.updateRefs true


### PR DESCRIPTION
## 概要

新しく Mac をセットアップしたときに `git config --global rebase.updateRefs true` が自動で入るように `mac_install.sh` に 1 行追加する。

## 背景

`rebase.updateRefs = true` は stacked / worktree ベースの複数ブランチ運用時に、rebase 中に「基点になっている中間ブランチの参照」も一緒に前進させてくれる設定。有効にしておかないと `git rebase --update-refs` を都度打つ必要があり忘れやすい。個人リポジトリ・OSS 貢献の両方で常に有効にしておきたい。

## 変更内容

- `mac_install.sh`: 末尾付近に `git config --global rebase.updateRefs true` を追加

`~/.gitconfig` そのものは個人 email 等が入っていて公開したくないので dotfiles にはトラックせず、コマンド 1 行流すだけの形にする。

## 動作確認

- [ ] `mac_install.sh` 実行後、`git config --global --get rebase.updateRefs` が `true` を返すこと
- [ ] 既存の `~/.gitconfig` の他の設定に影響が無いこと