### PR TITLE
chore(claude): require absolute paths when citing files in reports

### DIFF
--- a/claude/REPORT_WRITING.md
+++ b/claude/REPORT_WRITING.md
@@ -24,6 +24,7 @@ After the TL;DR, structure the body so the following five questions are answered
 - Prefer tables for any comparison across ≥2 variants or ≥2 metrics.
 - When numbers are noisy, report mean **and** spread (sd / min-max / iter count). A single-run number without spread is not evidence of a difference.
 - Cite the raw data location (file path, run ID, dashboard URL) so a reader can verify.
+- **Use absolute paths** whenever a file is referenced (e.g. `/Users/foo/project/src/bar.py:42`, not `src/bar.py:42`). Readers of the report may be in a different working directory, and relative paths lose meaning once the report is pasted into Slack, a PR description, or read again later.
 
 ## Style
 


### PR DESCRIPTION
## 概要

`claude/REPORT_WRITING.md` に「レポート中でファイルを参照する時は必ず絶対パスで書く」というルールを追加する。

## 背景

レポート内で `src/foo.py:42` のような相対パスで書かれると、読み手のカレントディレクトリが違うと参照先が定まらず、Slack や PR description に貼られて後日読まれたときに解釈が曖昧になる。ユーザから明示的に「必ず絶対パスで提示するように」という指示があった。

## 変更内容

- `claude/REPORT_WRITING.md`
  - "Concrete-data requirement" セクションに絶対パス要求の bullet を 1 行追加

## 動作確認

- [ ] symlink 経由で `~/.claude/REPORT_WRITING.md` にも反映されていること (`readlink ~/.claude/REPORT_WRITING.md` が dotfiles を指している)