### PR TITLE
chore(ghostty): switch font-family from Monaco to Menlo

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -10,7 +10,7 @@ macos-option-as-alt = left
 keybind = alt+enter=text:\n
 
 # Font
-font-family = "Monaco"
+font-family = "Menlo"
 font-size = 14
 
 # Theme


### PR DESCRIPTION
## 概要

Ghostty の `font-family` を Monaco から Menlo に切り替える。iTerm2 のデフォルトに合わせるのが狙い。

## 背景

Monaco は Regular variant しか持たないため、Ghostty がプロンプト強調表示等の bold で fallback を挟む必要があり、実質的に "Monaco だけ" では描画されていなかった。Menlo は Regular / Bold / Italic / Bold Italic 全て揃っているのでこの問題が起きない。日本語部分は Monaco 時と同じく macOS 標準の Hiragino Sans にフォールバックする（iTerm2 デフォルトも同じ挙動）。

## 変更内容

- `ghostty/config`
  - `font-family = "Monaco"` → `font-family = "Menlo"`

## 動作確認

- [ ] Ghostty を再起動して `ghostty +show-config | grep font-family` が Menlo を返すこと
- [ ] `Bold` 表示が algorithmic bold ではなく Menlo Bold として描画されていること (`ghostty +show-config | grep font-family-bold` が Menlo)
- [ ] 日本語の描画が従来通り Hiragino Sans になっていること