### PR TITLE
fix(ghostty): pin Japanese fallback to Hiragino Sans

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -10,7 +10,12 @@ macos-option-as-alt = left
 keybind = alt+enter=text:\n
 
 # Font
+# Menlo has no CJK glyphs; without an explicit JP fallback CoreText picks
+# a monospace-with-JP font like HackGen Console NF (from brew cask
+# font-hackgen-nerd) over Hiragino Sans (proportional). Pin Hiragino Sans
+# here so Japanese renders in the iTerm2-default style.
 font-family = "Menlo"
+font-family = "Hiragino Sans"
 font-size = 14
 
 # Theme


### PR DESCRIPTION
## 概要

Ghostty で `font-family = "Menlo"` を指定していても、日本語文字が Hiragino Sans ではなく HackGen Console NF で描画されていた問題を修正する。

## 原因

- Menlo は Latin only なので、日本語部分は CoreText の fallback に任される
- CoreText は primary font が monospace の場合、fallback にも monospace を優先する
- `brew install --cask font-hackgen-nerd` で HackGen Console NF (monospace かつ JP glyph あり) が導入されており、Hiragino Sans (proportional) より優先されていた

`ghostty +show-face --string="あいうえおマージ完了"` で全 JP 文字が `HackGen Console NF` にヒットしていることを確認済み。

## 変更内容

- `ghostty/config`
  - `font-family = "Menlo"` の下に `font-family = "Hiragino Sans"` を追加。Ghostty の複数 `font-family` 行は明示的 fallback chain として機能するため、これで JP は Hiragino Sans にロックされる

## 動作確認

- [ ] Ghostty 再起動後、`ghostty +show-face --string="あいうえお"` が全て `Hiragino Sans` を返すこと
- [ ] Latin 表示が Menlo のまま変わっていないこと