### PR TITLE
fix(ghostty): thicken Japanese fallback to Hiragino Sans W4

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -15,7 +15,7 @@ keybind = alt+enter=text:\n
 # font-hackgen-nerd) over Hiragino Sans (proportional). Pin Hiragino Sans
 # here so Japanese renders in the iTerm2-default style.
 font-family = "Menlo"
-font-family = "Hiragino Sans"
+font-family = "Hiragino Sans W5"
 font-size = 14
 
 # Theme

--- a/ghostty/config
+++ b/ghostty/config
@@ -15,7 +15,7 @@ keybind = alt+enter=text:\n
 # font-hackgen-nerd) over Hiragino Sans (proportional). Pin Hiragino Sans
 # here so Japanese renders in the iTerm2-default style.
 font-family = "Menlo"
-font-family = "Hiragino Sans W5"
+font-family = "Hiragino Sans W4"
 font-size = 14
 
 # Theme


### PR DESCRIPTION
## 概要

Ghostty の日本語 fallback を `Hiragino Sans` (デフォルトの W3 = Regular 相当) から `Hiragino Sans W5` に変更する。Menlo Regular に対して W3 は視覚的にかなり細く、Latin と日本語で線の太さがバラついて日本語が読みづらいため。

## 変更内容

- `ghostty/config`
  - fallback 行を `font-family = "Hiragino Sans"` → `font-family = "Hiragino Sans W5"` に変更

## 動作確認

- [ ] Ghostty 再起動後、`ghostty +show-face --string="あマ完"` が `Hiragino Sans W5` を返すこと
- [ ] Menlo (Latin) との視覚的な太さバランスが改善していること